### PR TITLE
docker-compose: Use FLASK_DEBUG, which is not deprecated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - .:/build
     environment:
       - FLASK_APP=viewer.py
-      - FLASK_ENV=development
+      - FLASK_DEBUG=true
     command: bash -c "cd /build && pip install -r requirements.txt && flask run --host=0.0.0.0"
 
   db:


### PR DESCRIPTION
This PR changes the Flask debugging env var to be the one which isn't deprecated.

https://flask.palletsprojects.com/en/latest/config/#DEBUG