### PR TITLE
readme: refer to the right URL [ci skip]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,4 +48,4 @@ flask run
 docker-compose up
 ```
 
-The website can be found at 127.0.0.1:5000.
+The website will start running on http://0.0.0.0:5000.


### PR DESCRIPTION
When running Docker Compose, this is the actual address being printed in the output.