### PR TITLE
Add a missing space in Recommend name picker

### DIFF
--- a/templates/recommend_1.html
+++ b/templates/recommend_1.html
@@ -28,7 +28,7 @@
                     <div class="input-group-text ">
                       <input class="form-check-input" type="radio" name="persona"  value="{{g[0]}}" id="persona-{{g[0] | urlencode }}" aria-label="Radio button for {{g[1]}}">
                     </div>
-                    <span class="input-group-text flex-grow-1">{{g[1]}} {%if g[3] %} <span class="text-muted">(also known as {{ g[3] }})</span>{% endif %}</span>
+                    <span class="input-group-text flex-grow-1">{{g[1]}} {%if g[3] %} <span class="text-muted"> (also known as {{ g[3] }})</span>{% endif %}</span>
                   </div>
                 </div>
               </label>


### PR DESCRIPTION
Avoid a missing space situation:

<img width="114" alt="bild" src="https://github.com/drachenwald/dw_op/assets/211/88ac7ba7-205f-4481-ae83-3daa9f15ec62">
