### PR TITLE
Avoid double commas in Persona alt_names listing output

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -395,9 +395,9 @@ def match_persona(c, name):
 
 def db_search_persona(cursor, name):
     if(name.isnumeric()):
-        return do_query(cursor,"""SELECT DISTINCT p_full.id, p_full.name, p_full.person_id, substring(alt_names, 1, length(alt_names) - 1) AS alt_names
+        return do_query(cursor,"""SELECT DISTINCT p_full.id, p_full.name, p_full.person_id, alt_names
 FROM personae p
-	LEFT JOIN (SELECT p1.person_id, p1.id, group_concat(p2.name, ',') AS alt_names, p1.name
+	LEFT JOIN (SELECT p1.person_id, p1.id, group_concat(p2.name SEPARATOR ', ') AS alt_names, p1.name
 			FROM personae AS p1
 					LEFT JOIN personae AS p2 ON p1.person_id = p2.person_id AND p2.official = 0
 			WHERE p1.official = 1
@@ -405,9 +405,9 @@ FROM personae p
 			ON p.person_id = p_full.person_id
 WHERE p.id =%s ORDER BY p_full.name""", name)
     else:
-        return do_query(cursor,"""SELECT DISTINCT p_full.id, p_full.name, p_full.person_id, substring(alt_names, 1, length(alt_names) - 1) AS alt_names
+        return do_query(cursor,"""SELECT DISTINCT p_full.id, p_full.name, p_full.person_id, alt_names
 FROM personae p
-	LEFT JOIN (SELECT p1.person_id, p1.id, group_concat(p2.name, ',') AS alt_names, p1.name
+	LEFT JOIN (SELECT p1.person_id, p1.id, group_concat(p2.name SEPARATOR ', ') AS alt_names, p1.name
 			FROM personae AS p1
 					LEFT JOIN personae AS p2 ON p1.person_id = p2.person_id AND p2.official = 0
 			WHERE p1.official = 1


### PR DESCRIPTION
This PR fixes a presentation issue, of the "also known as" persona names that are presented in search results.

The problem was in a database query.

## Reproducing and showing the bug fixed here

The data in the dev environment does not supply an example of someone with > 2 personae, so the commas issue was not showing in dev.

```sql
-- In order to add some extra personae for the same person, 
-- examples exist in the production data.
INSERT INTO personae (id, name, person_id, official, search_name)
  VALUES (3637,  "Anna HURRA", 3229, 0, NULL);
INSERT INTO personae (id, name, person_id, official, search_name)
  VALUES (3638, "Anna Wunder", 3229, 0, NULL);
```

Now, this query fragment inspired by db_search_persona(). It shows the issue with the commas:

```sql
SELECT
  p1.person_id,
  p1.id,
  group_concat(p2.name, ',') AS alt_names,
  substring(group_concat(p2.name, ','), 1, length(group_concat(p2.name, ',')) - 1) alt_names_no_ending_comma,
  p1.name
FROM personae AS p1
  LEFT JOIN personae AS p2 ON p1.person_id = p2.person_id AND p2.official = 0
WHERE p1.official = 1
GROUP BY p1.id;
```

Using this: we can see the double output of commas.

```
MariaDB [drachdb]> SELECT
    ->   p1.person_id,
    ->   p1.id,
    ->   group_concat(p2.name, ',') AS alt_names,
    ->   substring(group_concat(p2.name, ','), 1, length(group_concat(p2.name, ',')) - 1) alt_names_no_ending_comma,
    ->   p1.name
    -> FROM personae AS p1
    ->   LEFT JOIN personae AS p2 ON p1.person_id = p2.person_id AND p2.official = 0
    -> WHERE p1.official = 1
    -> GROUP BY p1.id;
+-----------+------+------------------------------------------------------+-----------------------------------------------------+--------------------------+
| person_id | id   | alt_names                                            | alt_names_no_ending_comma                           | name                     |
+-----------+------+------------------------------------------------------+-----------------------------------------------------+--------------------------+
|      1557 | 1545 | NULL                                                 | NULL                                                | John The Green           |
|      2489 | 2418 | NULL                                                 | NULL                                                | íone                     |
|      3226 | 3623 | NULL                                                 | NULL                                                | Thomas                   |
|      3227 | 3624 | NULL                                                 | NULL                                                | Sara of Nordmark         |
|      3228 | 3625 | NULL                                                 | NULL                                                | Yda                      |
|      3229 | 3626 | Anna wiht a different name,,ANNA HURRA,,Anna Wunder, | Anna wiht a different name,,ANNA HURRA,,Anna Wunder | Anna S. Þorvaldsdóttir   |
|      3230 | 3627 | NULL                                                 | NULL                                                | Tiffany                  |
|      3231 | 3628 | NULL                                                 | NULL                                                | Seamus                   |
|      3232 | 3629 | NULL                                                 | NULL                                                | Sven The Red             |
|      3233 | 3630 | NULL                                                 | NULL                                                | Hildegard                |
|      3234 | 3631 | NULL                                                 | NULL                                                | James                    |
|      3235 | 3632 | NULL                                                 | NULL                                                | Eduard                   |
|      3236 | 3633 | NULL                                                 | NULL                                                | Einli                    |
|      3237 | 3634 | NULL                                                 | NULL                                                | Florence                 |
|      3238 | 3636 | NULL                                                 | NULL                                                | Anna of Polderslot       |
+-----------+------+------------------------------------------------------+-----------------------------------------------------+--------------------------+
15 rows in set (0.002 sec)
```

Reading the [docs for group_concat](https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html#function_group-concat) I saw that the syntax included a SEPARATOR keyword. So, I used that.

Then I saw that the workaround to "drop final comma" could be removed, too.

After this change, it output the expected number of commas.

<img width="721" alt="bild" src="https://github.com/drachenwald/dw_op/assets/211/3f095c54-3828-4b3e-9c2f-7b352f1ae3d1">

