### PR TITLE
refactor: get_armorial.py - drop unused local variable

### DIFF
--- a/get_armorial.py
+++ b/get_armorial.py
@@ -1,6 +1,8 @@
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseDownload
+import io
 import config
 
 def get_gdrive_service():
@@ -34,9 +36,6 @@ credentials = service_account.Credentials.from_service_account_info(info=cred_in
 service = build('drive', 'v3', credentials=credentials)
 page_token = None
 
-parents = ['1uaESfAUtJbO8eXhbdYOjOShZ_ub2QccT']
-
-
 response = service.files().list(q="parents in '1uaESfAUtJbO8eXhbdYOjOShZ_ub2QccT'",
                                             corpora='allDrives',
                                             supportsAllDrives=True,
@@ -45,15 +44,11 @@ response = service.files().list(q="parents in '1uaESfAUtJbO8eXhbdYOjOShZ_ub2QccT
                                                    'files(id, name,parents,mimeType,webContentLink)',
                                             pageToken=page_token).execute()
 
-results = response
-items = results.get('files', [])
-import io
-from googleapiclient.http import MediaIoBaseDownload
+items = response.get('files', [])
 for item in items:
     print(item['name'])
     print(item['mimeType'])
     if (item['mimeType'] == 'image/png') or (item['mimeType'] == 'image/svg+xml') :
-
         fileId = item['id']
         rst = service.files().get_media(fileId = fileId)
         file = io.BytesIO()
@@ -66,4 +61,3 @@ for item in items:
         with open("%s/%s" %(config.ARMORIAL_PATH,item['name'].strip()), "wb") as f:
             f.write(file.getbuffer())
             #print(file.getvalue())
-


### PR DESCRIPTION
This PR tries to tidy up a little in this script.

...move imports to top of file
...omit the intermediate results local variable at the bottom of the script

I am not 100% sure of whether this is a script to be reused, or where it is executed.