### PR TITLE
Display exception text when in DEBUG mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,7 @@
     <meta property="og:image" content="{{ url_for('static', filename='images/default-banner.jpg') }}" />
     <meta property="og:title" content="{{title_string}}" />
 
-    {% if config.ENV == 'development' %}
+    {% if config.DEBUG %}
 
     <meta name="robots" content="noindex">
 
@@ -43,7 +43,7 @@
 
     <header id="header">
 
-      {% if config.ENV == 'development' %}
+      {% if config.DEBUG %}
 
         <div class="bg-warning">
           <div class="container text-center">

--- a/templates/exception.html
+++ b/templates/exception.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Something went wrong!</h1>
 
-{% if config.ENV == 'development' %}
+{% if config.DEBUG %}
 <pre>{{ ex }}</pre>
 {% endif %}
 


### PR DESCRIPTION
This was missing when I changed away from the ENV=development to this.

With this, we see the error messages rather than only 500.

Also, add back the banner "you are on a development website"
<img width="464" alt="bild" src="https://github.com/drachenwald/dw_op/assets/211/eb4ffe63-5ae5-4913-948b-c950d7fdab78">
