### PR TITLE
Fix link to email the webminister

### DIFF
--- a/templates/exception.html
+++ b/templates/exception.html
@@ -7,5 +7,5 @@
 <pre>{{ ex }}</pre>
 {% endif %}
 
-<p>Please report the problem to <a href="mail:webminister@drachenwald.sca.org">webminister@drachenwald.sca.org</a>, with a description of what you were doing.</p>
+<p>Please report the problem to <a href="mailto:webminister@drachenwald.sca.org">webminister@drachenwald.sca.org</a>, with a description of what you were doing.</p>
 {% endblock %}


### PR DESCRIPTION
Use `mailto:`.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#linking_to_an_email_address