### PR TITLE
Use latest release of MySQL Connector-Python (October 2023), and latest Python

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   python:
-    image: 'python:3.5'
+    image: 'python:3.12'
     ports:
       - "127.0.0.1:5000:5000"
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask
 protobuf==3.17.3
 google-api-python-client==1.12.11
-https://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.tar.gz
-google-auth-httplib2 
-google-auth-oauthlib 
+https://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.1.8.tar.gz
+google-auth-httplib2
+google-auth-oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask
-protobuf==3.17.3
+protobuf <=4.21.12, >=4.21.1
 google-api-python-client==1.12.11
-https://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.1.8.tar.gz
+mysql-connector-python~=8.2.0
 google-auth-httplib2
 google-auth-oauthlib


### PR DESCRIPTION
This PR updates the docker-compose.yml to use latest Python release, and the latest release of the mysql database connector library.

## Background

I clicked through all the news messages of the mysql database connector library, then tried to update to this version (2.1.8), and it works.

1. https://dev.mysql.com/doc/relnotes/connector-python/en/news-2-0.html
2. https://dev.mysql.com/doc/relnotes/connector-python/en/news-2-1.html

First thoughts: "This is probably the better tiny upgrade, rather than going to 2.0.5."

## Detail

- Then, I looked at all the release notes, and saw that the 2.x to 8.0 version jump seemed to be about the (non-released) 2.2 introduction of something called the Dev X API.
- I also learned how to express multiple version specifiers for a dependency in `requirements.txt`: I needed that, in order to tell it which exact version range was acceptable (the range in the commit was taken from `docker-compose up` output). Source: https://pip.pypa.io/en/stable/reference/requirements-file-format/
- [Flask recommends "latest Python".](https://flask.palletsprojects.com/en/3.0.x/installation/#python-version)

