### PR TITLE
Add DW_OP_-prefixed env vars available for database

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,9 @@
-import os.path
+import os
 
-DB_USER = 'op'
-DB_PWD = 'op'
-DB_DATABASE = 'drachdb'
-DB_HOST ='db'
+DB_USER = os.getenv('DW_OP_DB_USER', 'op')
+DB_PWD = os.getenv('DW_OP_DB_PWD', 'op')
+DB_DATABASE = os.getenv('DW_OP_DB_DATABASE', 'drachdb')
+DB_HOST = os.getenv('DW_OP_DB_HOST', 'db')
 
 DISABLE_AUTH = False
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,10 @@ services:
     volumes:
       - .:/build
     environment:
+      - DW_OP_DB_PWD=op
+      - DW_OP_DB_USER=op
+      - DW_OP_DB_DATABASE=drachdb
+      - DW_OP_DB_HOST=db
       - FLASK_APP=viewer.py
       - FLASK_DEBUG=true
     command: bash -c "cd /build && pip install -r requirements.txt && flask run --host=0.0.0.0"


### PR DESCRIPTION
This PR is a "developer-experience" improvement. In order to be able to choose what password etc is used for the MySQL database, the config.py file reads those values from environment variables rather than fixing them to a value.

This allows for having more-secure passwords for databases that have that requirement, such as they have if they ran the secure setup script that comes with a Homebrew-installed MySQL.

If absent, the values fall back to the ones already in place.

In order to document the presence of these env vars, I changed the docker-compose.yml's used environment variables.

I tried to set a wrong database, and got a good 500 error in the development mode of the website.

To add more environment variables, we can re-use this prefix. Perhaps it becomes easy enough to search the codebase for it, to find and document.