### PR TITLE
navigation links: Let "Search" point to the quick search page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
 
         <div class="container">
 
-          <a class="navbar-brand" style="color: #ffff00;" href="/">
+          <a class="navbar-brand" style="color: #ffff00;" href="https://drachenwald.sca.org/">
             <img src="{{ url_for('static', filename='images/heraldry.svg') }}" width="50" alt="" /> Drachenwald
           </a>
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -17,7 +17,7 @@
 
   <div class="collapse navbar-collapse" id="top-banner-menu">
     <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-      <li class="nav-item"><a class="nav-link" href="{{ url_for('search') }}">Search</a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('front') }}">Search</a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('awards') }}">Awards</a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('op') }}">OP</a></li>
       <li class="nav-item"><a class="nav-link" href="{{ url_for('reigns') }}">Reigns</a></li>


### PR DESCRIPTION
- Search in navlist links now navigates to "quick search". From there is an easy way to get to the Advanced Search page.
- The logo in the top-left corner links to the main website.
 
Fixes #87. 

## Discussion

First, it was found that the homepage icon pointing back to the main website is a Good Thing, something we want. "- that's established behaviour and expectation." someone said.

It was brought up that the start page of dw_op is a Quick Search page, which is not linked from anywhere else but "being the start page".

We wished to keep that Quick Search page available.

> The reason we put the simple search on the front page is that most people who go to the OP want to look somebody up
> and they couldn't figure out where to search.

Resolution: the first link in the list of links in the navlist of yellow links ("Search") on red background will now point to https://op.drachenwald.sca.org/ rather than to https://op.drachenwald.sca.org/search
