### PR TITLE
Fixed a typo on recommendation confirmation page

### DIFF
--- a/templates/recommend_4.html
+++ b/templates/recommend_4.html
@@ -3,7 +3,7 @@
 {% block content %}
   <div id="content">
     <div class="text-center w-100">
-      <p><strong>Your have sent the following recommendation: </strong></p>
+      <p><strong>You have sent the following recommendation: </strong></p>
       <pre> {{ data.body }} </pre>
       <div class="text-center w-100">
         <div class="col-12 col-md-10 col-lg-8 mx-auto">


### PR DESCRIPTION
Got an email about this. Small typo, should be you instead of  your.