### PR TITLE
Awards search sorting and showing current name on search lists

### DIFF
--- a/sql-init/dev-db2.sql
+++ b/sql-init/dev-db2.sql
@@ -2032,20 +2032,21 @@ INSERT INTO `people` (`id`, `surname`, `forename`, `region_id`,`blazon`,`emblazo
 -- Dumping data for table `personae`
 --
 
-INSERT INTO `personae` VALUES (1545,'John The Green',1557,1,'');
-INSERT INTO `personae` VALUES (2418,'íone',2489,1,'ione ionne');
-INSERT INTO `personae` VALUES (3623,'Thomas',3226,1,'');
-INSERT INTO `personae` VALUES (3624,'Sara of Nordmark',3227,1,'');
-INSERT INTO `personae` VALUES (3625,'Yda',3228,1,'');
-INSERT INTO `personae` VALUES (3626,'Anna S. Þorvaldsdóttir',3229,1,'Anna S. Thorvaldsdóttir  Anna S. Thorvaldsdottir');
-INSERT INTO `personae` VALUES (3627,'Tiffany',3230,1,'');
-INSERT INTO `personae` VALUES (3628,'Seamus',3231,1,'');
-INSERT INTO `personae` VALUES (3629,'Sven The Red',3232,1,'');
-INSERT INTO `personae` VALUES (3630,'Hildegard',3233,1,'');
-INSERT INTO `personae` VALUES (3631,'James',3234,1,'');
-INSERT INTO `personae` VALUES (3632,'Eduard',3235,1,'Edward');
-INSERT INTO `personae` VALUES (3633,'Einli',3236,1,'');
-INSERT INTO `personae` VALUES (3634,'Florence',3237,1,'');
+INSERT INTO `personae` VALUES (1545,'John The Green','He/Him',1,1557,1,'');
+INSERT INTO `personae` VALUES (2418,'íone','They/Them',1,2489,1,'ione ionne');
+INSERT INTO `personae` VALUES (3623,'Thomas','',0,3226,1,'');
+INSERT INTO `personae` VALUES (3624,'Sara of Nordmark','She/Her',1,3227,1,'');
+INSERT INTO `personae` VALUES (3625,'Yda','She/Her',1,3228,1,'');
+INSERT INTO `personae` VALUES (3626,'Anna S. Þorvaldsdóttir','She/Her',1,3229,1,'Anna S. Thorvaldsdóttir  Anna S. Thorvaldsdottir');
+INSERT INTO `personae` VALUES (3627,'Tiffany','She/Her',0,3230,1,'');
+INSERT INTO `personae` VALUES (3628,'Seamus','He/Him',1,3231,1,'');
+INSERT INTO `personae` VALUES (3629,'Sven The Red','He/Him',1,3232,0,'');
+INSERT INTO `personae` VALUES (3630,'Hildegard','She/Her',1,3233,1,'');
+INSERT INTO `personae` VALUES (3631,'James','He/Him',1,3234,0,'');
+INSERT INTO `personae` VALUES (3632,'Eduard','He/Him',1,3235,1,'Edward');
+INSERT INTO `personae` VALUES (3633,'Einli','She/Her',1,3236,1,'');
+INSERT INTO `personae` VALUES (3634,'Florence','She/Her',1,3237,1,'');
+INSERT INTO `personae` VALUES (3635,'Jeanne','She/Her',1,3232,1,'');
 
 -- --------------------------------------------------------
 

--- a/templates/awards.html
+++ b/templates/awards.html
@@ -1,23 +1,36 @@
 {% extends "base.html" %}
+{% block head %}
+  {{ super() }}
+  {{ macros.tablesort_head() }}
+{% endblock %}
 {% block title %}Search by Award{% endblock %}
 {% block content %}
 <div id="content">
   {% if results %}
   <div id="awards">
 
-    <div class="list-group col-12 col-md-8 col-lg-6 mx-auto shadow mb-4">
-
-      {% for i in results | sort(attribute='0') %}
-
-        <a href="{{ url_for('persona', name=i[0]) }}" class="list-group-item list-group-item-action">
-          <div class="d-flex w-100 justify-content-between">
-            <span>{{i[0]}}</span>
-            <span class="text-muted me-3">{{i[2]}}</span>
-          </div>
-        </a>
-
-      {% endfor %}
-    </div>
+    <table class="results">
+      <thead>
+        <tr>
+          <th data-sort-default>Name</th>
+          <th>Award</th>
+          <th>Date</th>
+          <th>Crown</th>
+          <th>Event</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for i in results -%}
+        <tr>
+          <td><a href="{{ url_for('persona', name=i[0]) }}">{{i[0]}}</a></td>
+          <td>{{i[1]}}</td>
+          <td>{{i[2]}}</td>
+          <td>{{i[3]}}</td>
+          <td>{{i[4]}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
 
   </div>
   {% endif %}
@@ -140,10 +153,16 @@
 
     <div class="text-center w-100 mt-4">
       <div class="d-grid gap-2 col-6 col-lg-4 mx-auto mb-5 shadow">
-        <button type="submit" value="Search" class="btn btn-primary shadow" href="{{ url_for('search') }}">Search</a>
+        <button type="submit" value="Search" class="btn btn-primary shadow" href="{{ url_for('search') }}">Search</button>
       </div>
     </div>
 
   </form>
 </div>
+
+    <script>
+  for (let t of document.getElementsByClassName('results')) {
+    new Tablesort(t);
+  }
+</script>
 {% endblock %}

--- a/viewer.py
+++ b/viewer.py
@@ -216,7 +216,7 @@ def awards():
             flash('Please choose at least one award type.', 'info')
             results = list()
         else:
-            results = do_query(c, 'SELECT personae.name, award_types.name, awards.date, crowns.name, events.name FROM awards JOIN personae ON awards.persona_id = personae.id JOIN award_types ON awards.type_id = award_types.id JOIN events ON awards.event_id = events.id LEFT OUTER JOIN crowns ON awards.crown_id = crowns.id WHERE award_types.id IN ({}) ORDER BY awards.date, personae.name, award_types.name'.format(','.join(['%s'] * len(a_ids))), *a_ids)
+            results = do_query(c, 'SELECT cur.name, award_types.name, awards.date, crowns.name, events.name FROM awards JOIN personae ON awards.persona_id = personae.id JOIN award_types ON awards.type_id = award_types.id JOIN events ON awards.event_id = events.id LEFT OUTER JOIN crowns ON awards.crown_id = crowns.id JOIN personae AS cur ON personae.person_id = cur.person_id WHERE award_types.id IN ({}) AND cur.official = 1 ORDER BY awards.date, personae.name, award_types.name'.format(','.join(['%s'] * len(a_ids))), *a_ids)
 
     return render_template(
         'awards.html',
@@ -256,7 +256,7 @@ def award():
     results = None
 
     c = get_db().cursor()
-    results = do_query(c, 'SELECT personae.name, award_types.name, awards.date, crowns.name, events.name FROM personae JOIN awards ON personae.id = awards.persona_id JOIN award_types ON awards.type_id = award_types.id JOIN events ON awards.event_id = events.id LEFT OUTER JOIN crowns ON awards.crown_id = crowns.id WHERE award_types.name LIKE %s ORDER BY awards.date, personae.name, award_types.name', '%{}%'.format(award))
+    results = do_query(c, 'SELECT cur.name, award_types.name, awards.date, crowns.name, events.name FROM personae JOIN awards ON personae.id = awards.persona_id JOIN award_types ON awards.type_id = award_types.id JOIN events ON awards.event_id = events.id LEFT OUTER JOIN crowns ON awards.crown_id = crowns.id JOIN personae AS cur ON personae.person_id = cur.person_id WHERE award_types.name LIKE %s AND cur.official = 1 ORDER BY awards.date, personae.name, award_types.name', '%{}%'.format(award))
 
     return render_template(
         'award.html',


### PR DESCRIPTION
Addressing issues https://github.com/drachenwald/dw_op/issues/78 (show current persona name in awards listings instead of the name the award was given in) and https://github.com/drachenwald/dw_op/issues/77 (sorting the search results on awards search).

- Edited the sql queries to return the current persona name instead of the name the award was given to in the search by awards
- Changed the awards search listing to have the same sortable table as the other search result listings, with the same default search order as it was prior to this change