### PR TITLE
Remove default title

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -150,10 +150,7 @@ def persona(name):
         emblazon = url_for('static', filename='images/arms/' + emblazon)
 
     awards = do_query(c, 'SELECT DISTINCT p2.name, award_types.name, awards.date, crowns.name, events.name, award_types.precedence FROM personae AS p1 JOIN personae AS p2 ON p1.person_id = p2.person_id JOIN awards ON p2.id = awards.persona_id JOIN award_types ON awards.type_id = award_types.id JOIN events ON awards.event_id = events.id LEFT OUTER JOIN crowns ON awards.crown_id = crowns.id WHERE p1.name = %s ORDER BY awards.date, award_types.name', uname)
-    highest= do_query(c, 'SELECT DISTINCT p2.name, award_types.name, awards.date, crowns.name, events.name, award_types.precedence, default_title FROM personae AS p1 JOIN personae AS p2 ON p1.person_id = p2.person_id JOIN awards ON p2.id = awards.persona_id JOIN award_types ON awards.type_id = award_types.id JOIN events ON awards.event_id = events.id LEFT OUTER JOIN crowns ON awards.crown_id = crowns.id WHERE p1.name = %s ORDER BY award_types.precedence desc, awards.date Limit 1', uname)
-
-    if (title == ''):
-        title = highest[0][6]        
+    highest= do_query(c, 'SELECT DISTINCT p2.name, award_types.name, awards.date, crowns.name, events.name, award_types.precedence FROM personae AS p1 JOIN personae AS p2 ON p1.person_id = p2.person_id JOIN awards ON p2.id = awards.persona_id JOIN award_types ON awards.type_id = award_types.id JOIN events ON awards.event_id = events.id LEFT OUTER JOIN crowns ON awards.crown_id = crowns.id WHERE p1.name = %s ORDER BY award_types.precedence desc, awards.date Limit 1', uname)
 
     return render_template(
         'persona.html',


### PR DESCRIPTION
As per the feature request, and especially the rollback request, on https://github.com/drachenwald/dw_op/issues/80, remove the default title from being processed at all, so that if a persona does not have a preferred title, it would not show anything (and most especially, not show "None" in its place either).