### PR TITLE
Error page: Render exception in monospace font

### DIFF
--- a/templates/exception.html
+++ b/templates/exception.html
@@ -2,21 +2,26 @@
 {% block title %}500 Internal Server Error{% endblock %}
 {% block content %}
 <h1>Something went wrong!</h1>
-<p><b>
-We're aware of the error and are actively debugging
-</b>
-</p>
 <p>
-data<br/>
-{{ data }}
+    <b>We're aware of the error and are actively debugging.</b>
 </p>
-<p><ex<br/>
-{{ ex }} 
-</p>
-{% if config.DEBUG %}
 
+<p>
+    Please report the problem to <a href="mailto:webminister@drachenwald.sca.org">webminister@drachenwald.sca.org</a>, with a description of what you were doing.
+</p>
+
+<h2>Data</h2>
+<pre>
+{{ data }}
+</pre>
+
+<h2>Exception</h2>
+<pre>
+{{ ex }} 
+</pre>
+
+{% if config.DEBUG %}
 
 {% endif %}
 
-<p>Please report the problem to <a href="mailto:webminister@drachenwald.sca.org">webminister@drachenwald.sca.org</a>, with a description of what you were doing.</p>
 {% endblock %}


### PR DESCRIPTION
This PR changes the exception page, which renders in case there was an error.

-  place the call to action before all the details, they can be long.
- use `<pre>` tags to see the backtrace rendered as it should be read (with formatted monospace font)

This helps readability, easing debugging.

I was inspired to do this by #107 that is about dealing with errors.

## What it looks like, with these changes

<img width="1059" height="776" alt="image" src="https://github.com/user-attachments/assets/33dabbc3-1906-4b7a-90dc-342466563825" />
