### PR TITLE
Respond with 404 if persona not found

### DIFF
--- a/templates/persona_not_found.html
+++ b/templates/persona_not_found.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{%- import "macros.html" as macros %}
+{% block title %}404 Not found{% endblock %}
+{% block content %}
+<div id="content">
+  <div id="details">
+    <div class="row">
+      <div class="col-12 col-sm-8 col-md-10 text-center text-sm-start">
+        <p>Persona with the name <b>{{ name }}</b> not found.</p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/viewer.py
+++ b/viewer.py
@@ -128,7 +128,11 @@ def persona(name):
 		LEFT JOIN titles on personae.id = titles.persona_id
 					and titles.main = True
 	WHERE personae.name = %s"""
-    person_id, has_modname, region, blazon, emblazon, pronouns, title, mod_name, show_mod = do_query(c, q, uname)[0]
+    result = do_query(c, q, uname)
+    if not result:
+        return render_template('persona_not_found.html', name=uname), 404
+
+    person_id, has_modname, region, blazon, emblazon, pronouns, title, mod_name, show_mod = result[0]
 
     official_id, official_name = do_query(c, 'SELECT id, name FROM personae WHERE person_id = %s AND official = 1', person_id)[0];
 


### PR DESCRIPTION
Fixes #107

Adds an early return code path rendering a new template (which can be extended and designed in any way we want) with the HTTP status code 404.

Example URL I used in testing `http://127.0.0.1:5000/persona/Anna%20S.%20Þorvaldsdóttirx`

## What it looks like when not finding

<img width="1348" height="534" alt="image" src="https://github.com/user-attachments/assets/6cb0b1f9-bb9d-4872-a243-f6a2ea151262" />
